### PR TITLE
Changed "search students" to include more #334

### DIFF
--- a/index.html
+++ b/index.html
@@ -1088,7 +1088,7 @@
             </div>
             <div class="headerbarpage searchbackground">
               <paper-icon-button class="grey" icon="arrow-back" onclick="closeSearchBar()"></paper-icon-button>
-              <paper-typeahead-input max-suggestions="5" placeholder="Search students" remote-url="/search/%QUERY" remote-url-wait-ms="100" is-candidates-json display-prop="name">
+              <paper-typeahead-input max-suggestions="5" placeholder="Search people" remote-url="/search/%QUERY" remote-url-wait-ms="100" is-candidates-json display-prop="name">
               </paper-typeahead-input>
             </div>
           </neon-animated-pages>


### PR DESCRIPTION
-Originally the search bar would say "Search students" despite the user being able to search more than just students
-Fixed so that it tells you you can search teachers too yay

Fixes #334.