### PR TITLE
Add support for impersonating users when running the dev server

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ SCHEDULE_INFO = None
 DAYS = None
 FALL_TRI_END = datetime.datetime(2020, 11, 23, 15, 30, 0, 0)
 WINT_TRI_END = datetime.datetime(2021, 3, 6, 15, 30, 0, 0)
+enable_impersonation = False
 
 def init_app(test_config=None, enable_impersonation=False):
     global verify_firebase_token

--- a/app.py
+++ b/app.py
@@ -20,14 +20,12 @@ DAYS = None
 FALL_TRI_END = datetime.datetime(2020, 11, 23, 15, 30, 0, 0)
 WINT_TRI_END = datetime.datetime(2021, 3, 6, 15, 30, 0, 0)
 
-def init_app(test_config=None, enable_impersonation=False):
+def init_app(test_config=None):
     global verify_firebase_token
     global datastore_client
     global SCHEDULE_INFO
     global DAYS
-    global enable_impersonation
     app.permanent_session_lifetime = datetime.timedelta(days=3650)
-    enable_impersonation = enable_impersonation
     if test_config is None:
         # Authenticate ourselves
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "service_account.json"
@@ -109,7 +107,8 @@ def get_database_entries(usernames):
 def main():
     # Tokens are used during login, but after that we use our own system
     # If they have a token, we should always eat it and give them either
-    # a proper auth cookie or the login page.
+    # a proper auth cookie or the login page
+
     token = request.cookies.get("token")
     if token:
         try:
@@ -131,13 +130,6 @@ def main():
         except ValueError as exc:
             return gen_login_response()
 
-    # For debugging, the local server allows one to impersonate a specific
-    # user by using the u= URL parameter. Use this with discretion;
-    # respect the privacy of others.
-    elif enable_impersonation and 'u' in request.args:
-        session['username'] = request.args['u']
-
-    # If we still don't know who you are, return the login page.
     elif 'username' not in session:
         return gen_login_response()
 

--- a/app.py
+++ b/app.py
@@ -19,7 +19,6 @@ SCHEDULE_INFO = None
 DAYS = None
 FALL_TRI_END = datetime.datetime(2020, 11, 23, 15, 30, 0, 0)
 WINT_TRI_END = datetime.datetime(2021, 3, 6, 15, 30, 0, 0)
-enable_impersonation = False
 
 def init_app(test_config=None, enable_impersonation=False):
     global verify_firebase_token

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
-from app import app, init_app
+from app import app, 
+import argparse
 
-init_app()
+init_app(enable_impersonation=True)
 
 if __name__ == '__main__':
     # Only used for running locally. When running on production, it will

--- a/main.py
+++ b/main.py
@@ -1,8 +1,21 @@
 from app import app, init_app
+from flask import abort, request, redirect, session
 
 init_app()
 
+# Only used for running locally. When running on production, it will
+# look for a variable named "app" in main.py and run that directly.
 if __name__ == '__main__':
-    # Only used for running locally. When running on production, it will
-    # look for a variable named "app" in main.py and run that directly.
+    # Allows impersonation of other users, for debugging purposes.
+    # We specifically only enable this when running locally, since we only
+    # want developers to have this sort of access. Even so, respect the
+    # privacy of others when using this mechanism.
+    @app.route('/login')
+    def handle_login():
+        if 'u' not in request.args:
+            return abort(400)
+
+        session['username'] = request.args['u']
+        return redirect('/')
+
     app.run(host='127.0.0.1', port=8080, debug=True)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
-from app import app, 
-import argparse
+from app import app, init_app
 
-init_app(enable_impersonation=True)
+init_app()
 
 if __name__ == '__main__':
     # Only used for running locally. When running on production, it will


### PR DESCRIPTION
http://localhost:8080/login?u=foo will log you in as ```foo```. This is only enabled when running main.py directly, i.e., not in prod (for obvious reasons).