### PR TITLE
Add no-op lunch task as an additional way to debug

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -2,3 +2,7 @@ cron:
 - description: update schedules
   url: /cron/schedules
   schedule: every 24 hours
+
+- description: update lunches
+  url: /cron/lunches
+  schedule: every 24 hours


### PR DESCRIPTION
The lunch task doesn't do anything right now other than print "OK", but we can see if it fails for some odd reason.