### PR TITLE
Remove service account from test runner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,5 @@ jobs:
           black . --check
           isort . --check --profile black
       - name: Test main
-        env:
-          SERVICE_ACCOUNT: ${{secrets.GCP_SERVICE_ACCOUNT}}
         run: |
-          echo '${{secrets.GCP_SERVICE_ACCOUNT}}' > service_account.json
           python main_test.py


### PR DESCRIPTION
This allows tests to run successfully on PRs from forks